### PR TITLE
fix Credential problem

### DIFF
--- a/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
+++ b/src/main/scala/se/radley/plugin/salat/SalatPlugin.scala
@@ -31,7 +31,7 @@ class SalatPlugin @Inject() (implicit app: Application) extends Plugin {
           val maybe = for {
             u <- user
             p <- password
-          } yield MongoCredential.createMongoCRCredential(u, dbName, p.toArray)
+          } yield MongoCredential.createCredential(u, dbName, p.toArray)
 
           List(maybe).flatten
         }


### PR DESCRIPTION
You are using MongoCredential.createMongoCRCredential to login with user name and pwd, but it's not working for default mongodb user(My mongo version is 3.2). I figure out that when we use the default MongoCredential.createCredential it works fine....
